### PR TITLE
🎨 Extract GitHub variables to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ REVIEW_CHANNEL=channel ID to post review messages to
 AIRTABLE_API_KEY=airtable api key
 AIRTABLE_BASE_ID=id of the airtable base
 GH_APP_ID=id of github app
+GH_INSTALLATION_ID=the installation id
 ```
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- DO NOT REMOVE - contributor_list:data:start:["cjdenio", "Matt-Gleich"]:end -->
+
 # awesome_hackclub_auto
 
 > Automation service for [awesome-hackclub](https://github.com/hackclub/awesome-hackclub)
@@ -17,6 +18,7 @@ SLACK_SIGNING_SECRET=signing secret, NOT verification token
 REVIEW_CHANNEL=channel ID to post review messages to
 AIRTABLE_API_KEY=airtable api key
 AIRTABLE_BASE_ID=id of the airtable base
+GH_APP_ID=id of github app
 ```
 
 ### Commands
@@ -31,8 +33,8 @@ AIRTABLE_BASE_ID=id of the airtable base
 | `docker ps`                   | View running services                                    |
 
 <!-- DO NOT REMOVE - contributor_list:start -->
-## 👥 Contributors
 
+## 👥 Contributors
 
 - **[@cjdenio](https://github.com/cjdenio)**
 

--- a/pkg/gh/auth.go
+++ b/pkg/gh/auth.go
@@ -3,6 +3,7 @@ package gh
 import (
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/Matt-Gleich/logoru"
 	"github.com/bradleyfalzon/ghinstallation"
@@ -12,7 +13,17 @@ import (
 // Authenticate with GitHub using the secret ssh key
 // Return a github client instance
 func Auth() *github.Client {
-	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, 81465, 99, "private-key.pem")
+	appId, err := strconv.Atoi(os.Getenv("GH_APP_ID"))
+	if err != nil {
+		logoru.Critical("The GH_APP_ID environment variable should be set, and a number")
+	}
+
+	installationId, err := strconv.Atoi(os.Getenv("GH_INSTALLATION_ID"))
+	if err != nil {
+		logoru.Critical("The GH_INSTALLATION_ID environment variable should be set, and a number")
+	}
+
+	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, int64(appId), int64(installationId), "private-key.pem")
 	if err != nil {
 		logoru.Critical("Failed to authenticate with GitHub using private key;", err)
 		os.Exit(1)


### PR DESCRIPTION
This PR avoids hard-coding the GitHub app ID and installation ID. The new env vars are `GH_APP_ID` and `GH_INSTALLATION_ID`, respectively.﻿
