### PR TITLE
🎨 Load GitHub private key from env variable

### DIFF
--- a/pkg/gh/auth.go
+++ b/pkg/gh/auth.go
@@ -23,7 +23,7 @@ func Auth() *github.Client {
 		logoru.Critical("The GH_INSTALLATION_ID environment variable should be set, and a number")
 	}
 
-	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, int64(appId), int64(installationId), "private-key.pem")
+	itr, err := ghinstallation.New(http.DefaultTransport, int64(appId), int64(installationId), LoadPrivateKey())
 	if err != nil {
 		logoru.Critical("Failed to authenticate with GitHub using private key;", err)
 		os.Exit(1)

--- a/pkg/gh/private_key.go
+++ b/pkg/gh/private_key.go
@@ -1,0 +1,19 @@
+package gh
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/Matt-Gleich/logoru"
+)
+
+func LoadPrivateKey() []byte {
+	key, err := ioutil.ReadAll(base64.NewDecoder(base64.StdEncoding, strings.NewReader(os.Getenv("GH_PRIVATE_KEY"))))
+	if err != nil {
+		logoru.Critical("Error reading GitHub private key")
+		return nil
+	}
+	return key
+}


### PR DESCRIPTION
This PR loads the base64-encoded GitHub private key from an environment variable, `GH_PRIVATE_KEY`.