### PR TITLE
🔊 Add fingerprint to Honeybadger notifications

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,9 +1,12 @@
 package logging
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
+
+	"crypto/rand"
 
 	"github.com/Matt-Gleich/logoru"
 	"github.com/honeybadger-io/honeybadger-go"
@@ -13,7 +16,7 @@ func Log(v interface{}, level string, localOnly bool) {
 	// Only log to Honeybadger if an API key is set and it's an error
 	if os.Getenv("HONEYBADGER_API_KEY") != "" && !localOnly && (level == "error" || level == "critical" || level == "warning") {
 		logoru.Info("Logging an error to Honeybadger...")
-		_, err := honeybadger.Notify(fmt.Sprintf("%s: %v", strings.ToUpper(level), v))
+		_, err := honeybadger.Notify(fmt.Sprintf("%s: %v", strings.ToUpper(level), v), honeybadger.Fingerprint{Content: genFingerprint()})
 		if err != nil {
 			logoru.Error("Ironically enough, something went wrong while trying to log an error :(")
 		}
@@ -33,4 +36,17 @@ func Log(v interface{}, level string, localOnly bool) {
 	case "success":
 		logoru.Success(v)
 	}
+}
+
+func genFingerprint() string {
+	fingerprint := make([]byte, 16)
+	_, err := rand.Read(fingerprint)
+	if err != nil {
+		_, err := honeybadger.Notify("Error generating Honeybadger fingerprint")
+		if err != nil {
+			logoru.Error("Ironically enough, something went wrong while trying to log an error :(")
+		}
+		return ""
+	}
+	return hex.EncodeToString(fingerprint)
 }


### PR DESCRIPTION
This PR adds a random fingerprint to each Honeybadger log, preventing them from being grouped together.